### PR TITLE
Fix tiny byte bug

### DIFF
--- a/src/main/java/com/gnopai/ji65/assembler/InstructionAssembler.java
+++ b/src/main/java/com/gnopai/ji65/assembler/InstructionAssembler.java
@@ -64,14 +64,15 @@ public class InstructionAssembler {
 
     private SegmentData assembleThreeByteInstruction(InstructionStatement instructionStatement, AddressingModeType zeroPageAddressingModeType, Environment environment) {
         boolean isZeroPage = expressionZeroPageChecker.isZeroPage(instructionStatement.getAddressExpression(), environment);
-        UnresolvedExpression operand = new UnresolvedExpression(instructionStatement.getAddressExpression(), isZeroPage);
-        if (operand.isSingleByte()) {
+        if (isZeroPage) {
             Optional<Opcode> zeroPageOpcode = Opcode.of(instructionStatement.getInstructionType(), zeroPageAddressingModeType);
             if (zeroPageOpcode.isPresent()) {
+                UnresolvedExpression operand = new UnresolvedExpression(instructionStatement.getAddressExpression(), true);
                 return new InstructionData(zeroPageOpcode.get(), operand);
             }
         }
         Opcode opcode = getOpcode(instructionStatement);
+        UnresolvedExpression operand = new UnresolvedExpression(instructionStatement.getAddressExpression(), false);
         return new InstructionData(opcode, operand);
     }
 

--- a/src/test/java/com/gnopai/ji65/assembler/InstructionAssemblerTest.java
+++ b/src/test/java/com/gnopai/ji65/assembler/InstructionAssemblerTest.java
@@ -192,7 +192,7 @@ class InstructionAssemblerTest {
 
         SegmentData segmentData = assemble(instructionStatement);
 
-        InstructionData expectedData = new InstructionData(expectedOpcode, new UnresolvedExpression(addressExpression, true));
+        InstructionData expectedData = new InstructionData(expectedOpcode, new UnresolvedExpression(addressExpression, false));
         assertEquals(expectedData, segmentData);
     }
 


### PR DESCRIPTION
Fixes issue where 3-byte instructions with zero-page operands that didn't have corresponding zero-page opcodes were only writing out 2 bytes.