### PR TITLE
Separate loading and running of programs

### DIFF
--- a/src/main/java/com/gnopai/ji65/Cpu.java
+++ b/src/main/java/com/gnopai/ji65/Cpu.java
@@ -29,6 +29,12 @@ public class Cpu {
         return memory[address.getValue()];
     }
 
+    public void load(Program program) {
+        program.getChunks().forEach(chunk ->
+                copyToMemory(chunk.getAddress(), chunk.getBytes())
+        );
+    }
+
     public void copyToMemory(Address address, List<Byte> bytes) {
         int i = address.getValue();
         for (byte b : bytes) {

--- a/src/main/java/com/gnopai/ji65/Ji65.java
+++ b/src/main/java/com/gnopai/ji65/Ji65.java
@@ -40,7 +40,8 @@ public class Ji65 {
     }
 
     public void run(Program program, Address startAddress, Cpu cpu, ProgramEndStrategy programEndStrategy) {
-        interpreter.run(program, startAddress, cpu, programEndStrategy);
+        cpu.load(program);
+        interpreter.run(startAddress, cpu, programEndStrategy);
     }
 
     public TestReport runTests(Program program) {

--- a/src/main/java/com/gnopai/ji65/Main.java
+++ b/src/main/java/com/gnopai/ji65/Main.java
@@ -7,6 +7,7 @@ import com.gnopai.ji65.test.StdoutTestReporter;
 import com.gnopai.ji65.test.TestReport;
 import com.gnopai.ji65.util.ErrorHandler;
 import com.gnopai.ji65.util.ErrorPrinter;
+import lombok.Builder;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -33,6 +34,16 @@ public class Main implements Callable<Integer> {
 
     @Option(names = "-p", description = "display passing tests and assertions")
     private boolean showPassingTests;
+
+    @Builder
+    private Main(File sourceFile, File programConfigFile, boolean showPassingTests) {
+        this.sourceFile = sourceFile;
+        this.programConfigFile = programConfigFile;
+        this.showPassingTests = showPassingTests;
+    }
+
+    private Main() {
+    }
 
     public static void main(String[] args) {
         Main main = new Main();

--- a/src/main/java/com/gnopai/ji65/interpreter/Interpreter.java
+++ b/src/main/java/com/gnopai/ji65/interpreter/Interpreter.java
@@ -2,7 +2,6 @@ package com.gnopai.ji65.interpreter;
 
 import com.gnopai.ji65.Address;
 import com.gnopai.ji65.Cpu;
-import com.gnopai.ji65.Program;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -16,12 +15,8 @@ public class Interpreter {
         this.instructionExecutor = instructionExecutor;
     }
 
-    public void run(Program program, Address startAddress, Cpu cpu, ProgramEndStrategy programEndStrategy) {
-        program.getChunks().forEach(chunk ->
-                cpu.copyToMemory(chunk.getAddress(), chunk.getBytes())
-        );
+    public void run(Address startAddress, Cpu cpu, ProgramEndStrategy programEndStrategy) {
         cpu.setProgramCounter(startAddress.getValue());
-
         while (!programEndStrategy.shouldEndProgram(cpu)) {
             instructionExecutor.execute(cpu);
         }

--- a/src/main/java/com/gnopai/ji65/test/Assertion.java
+++ b/src/main/java/com/gnopai/ji65/test/Assertion.java
@@ -2,7 +2,6 @@ package com.gnopai.ji65.test;
 
 import com.gnopai.ji65.Address;
 import com.gnopai.ji65.Cpu;
-import com.gnopai.ji65.Program;
 import lombok.Builder;
 import lombok.Value;
 
@@ -15,7 +14,7 @@ public class Assertion implements TestStep {
     String message;
 
     @Override
-    public void run(TestRunner testRunner, Cpu cpu, Program program) {
+    public void run(TestRunner testRunner, Cpu cpu) {
         testRunner.runStep(cpu, this);
     }
 }

--- a/src/main/java/com/gnopai/ji65/test/RunSubRoutine.java
+++ b/src/main/java/com/gnopai/ji65/test/RunSubRoutine.java
@@ -2,7 +2,6 @@ package com.gnopai.ji65.test;
 
 import com.gnopai.ji65.Address;
 import com.gnopai.ji65.Cpu;
-import com.gnopai.ji65.Program;
 import lombok.Builder;
 import lombok.Value;
 
@@ -12,7 +11,7 @@ public class RunSubRoutine implements TestStep {
     Address address;
 
     @Override
-    public void run(TestRunner testRunner, Cpu cpu, Program program) {
-        testRunner.runStep(cpu, this, program);
+    public void run(TestRunner testRunner, Cpu cpu) {
+        testRunner.runStep(cpu, this);
     }
 }

--- a/src/main/java/com/gnopai/ji65/test/SetValue.java
+++ b/src/main/java/com/gnopai/ji65/test/SetValue.java
@@ -2,7 +2,6 @@ package com.gnopai.ji65.test;
 
 import com.gnopai.ji65.Address;
 import com.gnopai.ji65.Cpu;
-import com.gnopai.ji65.Program;
 import lombok.Builder;
 import lombok.Value;
 
@@ -14,7 +13,7 @@ public class SetValue implements TestStep {
     int value;
 
     @Override
-    public void run(TestRunner testRunner, Cpu cpu, Program program) {
+    public void run(TestRunner testRunner, Cpu cpu) {
         testRunner.runStep(cpu, this);
     }
 }

--- a/src/main/java/com/gnopai/ji65/test/TestRunner.java
+++ b/src/main/java/com/gnopai/ji65/test/TestRunner.java
@@ -26,10 +26,11 @@ public class TestRunner {
     }
 
     private void runTest(Test test, Program program) {
-        testResultTracker.startTest(test);
         Cpu cpu = Cpu.builder().build();
+        cpu.load(program);
+        testResultTracker.startTest(test);
         test.getSteps()
-                .forEach(step -> step.run(this, cpu, program));
+                .forEach(step -> step.run(this, cpu));
     }
 
     void runStep(Cpu cpu, SetValue setValue) {
@@ -53,8 +54,8 @@ public class TestRunner {
         }
     }
 
-    void runStep(Cpu cpu, RunSubRoutine runSubRoutine, Program program) {
-        interpreter.run(program, runSubRoutine.getAddress(), cpu, new EndProgramAtRtsOnEmptyStack());
+    void runStep(Cpu cpu, RunSubRoutine runSubRoutine) {
+        interpreter.run(runSubRoutine.getAddress(), cpu, new EndProgramAtRtsOnEmptyStack());
     }
 
     private Byte getValue(Cpu cpu, Target target, Address targetAddress) {

--- a/src/main/java/com/gnopai/ji65/test/TestStep.java
+++ b/src/main/java/com/gnopai/ji65/test/TestStep.java
@@ -1,8 +1,7 @@
 package com.gnopai.ji65.test;
 
 import com.gnopai.ji65.Cpu;
-import com.gnopai.ji65.Program;
 
 public interface TestStep {
-    void run(TestRunner testRunner, Cpu cpu, Program program);
+    void run(TestRunner testRunner, Cpu cpu);
 }

--- a/src/test/java/com/gnopai/ji65/test/TestRunnerTest.java
+++ b/src/test/java/com/gnopai/ji65/test/TestRunnerTest.java
@@ -117,14 +117,13 @@ class TestRunnerTest {
     void testRunStep_runSubRoutine() {
         Address address = new Address(0x1234);
         RunSubRoutine runSubRoutine = new RunSubRoutine(address);
-        Program program = program();
         Cpu cpu = Cpu.builder().build();
 
         TestRunner testClass = new TestRunner(interpreter, testResultTracker);
 
-        testClass.runStep(cpu, runSubRoutine, program);
+        testClass.runStep(cpu, runSubRoutine);
 
-        verify(interpreter).run(eq(program), eq(address), eq(cpu), any(ProgramEndStrategy.class));
+        verify(interpreter).run(eq(address), eq(cpu), any(ProgramEndStrategy.class));
         verifyNoMoreInteractions(testResultTracker);
     }
 
@@ -164,7 +163,7 @@ class TestRunnerTest {
                 ))
         );
 
-        verify(interpreter).run(eq(program), eq(subRoutineAddress), any(Cpu.class), any(ProgramEndStrategy.class));
+        verify(interpreter).run(eq(subRoutineAddress), any(Cpu.class), any(ProgramEndStrategy.class));
         assertEquals(expectedResults, results);
     }
 


### PR DESCRIPTION
This allows tests to load the program first before setting up registers and whatnot, and then running what it needs. Otherwise all the set values get cleared with the program load.